### PR TITLE
fix(docusaurus, typescript): Bump Docusaurus beta version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "author": "Lucas Constantino Silva <lucasconstantinosilva@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^2.0.0-beta.15",
-    "@docusaurus/theme-classic": "^2.0.0-beta.15",
+    "@docusaurus/module-type-aliases": "^2.0.0-beta.18",
+    "@docusaurus/theme-classic": "^2.0.0-beta.18",
     "@docusaurus/types": "^2.0.0-beta.15",
     "@strv/commitlint-config": "^2.0.0",
     "@strv/eslint-config-node": "^3.0.0",
@@ -52,10 +52,10 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-beta.15",
-    "@docusaurus/preset-classic": "^2.0.0-beta.15",
-    "@docusaurus/theme-common": "^2.0.0-beta.15",
-    "@docusaurus/utils": "^2.0.0-beta.15",
+    "@docusaurus/core": "^2.0.0-beta.18",
+    "@docusaurus/preset-classic": "^2.0.0-beta.18",
+    "@docusaurus/theme-common": "^2.0.0-beta.18",
+    "@docusaurus/utils": "^2.0.0-beta.18",
     "@easyops-cn/docusaurus-search-local": "^0.21.4",
     "deepmerge": "^4.2.2",
     "mdx-mermaid": "^1.2.1",

--- a/src/sidebarItemsGenerator.ts
+++ b/src/sidebarItemsGenerator.ts
@@ -1,7 +1,8 @@
 import type {
   SidebarItemsGeneratorOption,
-  SidebarItem,
-  SidebarItemCategoryLink,
+  NormalizedSidebarItem,
+  SidebarItemCategoryLinkDoc,
+  SidebarItemCategoryLinkGeneratedIndexConfig,
 } from '@docusaurus/plugin-content-docs/src/sidebars/types'
 
 /**
@@ -18,10 +19,13 @@ const sidebarItemsGenerator: SidebarItemsGeneratorOption = async (context) => {
    * Finds a position of a sidebar item.
    */
   const getSidebarPosition = (
-    item: SidebarItem | SidebarItemCategoryLink | undefined
+    item:
+      | NormalizedSidebarItem
+      | SidebarItemCategoryLinkDoc
+      | SidebarItemCategoryLinkGeneratedIndexConfig
   ): number | undefined => {
-    if (item?.type === 'category') return getSidebarPosition(item.link ? item.link : item.items[0])
-    if (item?.type === 'doc') return docs[item.id].sidebarPosition
+    if (item.type === 'category') return getSidebarPosition(item.link ? item.link : item.items[0])
+    if (item.type === 'doc') return docs[item.id].sidebarPosition
   }
 
   /**
@@ -31,7 +35,7 @@ const sidebarItemsGenerator: SidebarItemsGeneratorOption = async (context) => {
    * 2. Add category labels based on index doc.
    * 3. Ensure sidebar_position is respected for automated trees.
    */
-  const processItem = (item: SidebarItem) => {
+  const processItem = (item: NormalizedSidebarItem) => {
     if (item.type === 'category') {
       // Fix root
       if (item.items.length === 0 && item.link?.type === 'doc') {


### PR DESCRIPTION
Bumping Docusaurus version to beta-18 which fixes some early stage issues and fixing typings for itemsGenerator

This PR doesn't change the @strv/docs package version. Should be in separate commit